### PR TITLE
Fix crash when window exit

### DIFF
--- a/src/vtkDearImGUIInjector.cxx
+++ b/src/vtkDearImGUIInjector.cxx
@@ -150,6 +150,7 @@ void vtkDearImGUIInjector::TearDown(vtkObject* caller, unsigned long eid, void* 
     interactor->SetDone(true);
   }
   ImGui_ImplOpenGL3_Shutdown();
+  vtkDebugMacro(<< "tear down");
 }
 
 void vtkDearImGUIInjector::BeginDearImGUIOverlay(
@@ -188,6 +189,8 @@ void vtkDearImGUIInjector::BeginDearImGUIOverlay(
   auto interactor = renWin->GetInteractor();
   this->UpdateMousePosAndButtons(interactor);
   this->UpdateMouseCursor(renWin);
+  
+  vtkDebugMacro(<< "new frame begin");
 
   // Begin ImGUI drawing
   ImGui_ImplOpenGL3_NewFrame();
@@ -232,6 +235,8 @@ void vtkDearImGUIInjector::BeginDearImGUIOverlay(
     ImGui::ShowAboutWindow(&this->ShowAppAbout);
   }
   this->InvokeEvent(ImGUIDrawEvent);
+  
+  vtkDebugMacro(<< "new frame end");
 }
 
 void vtkDearImGUIInjector::RenderDearImGUIOverlay(
@@ -385,7 +390,7 @@ void mainLoopCallback(void* arg)
   self->InstallEventCallback(interactor);
   interactor->ProcessEvents();
   self->UninstallEventCallback();
-  renWin->Render();
+  if (!interactor->GetDone()) renWin->Render();
 }
 }
 #endif
@@ -406,7 +411,8 @@ void vtkDearImGUIInjector::PumpEv(vtkObject* caller, unsigned long eid, void* ca
     this->InstallEventCallback(interactor);
     interactor->ProcessEvents();
     this->UninstallEventCallback();
-    renWin->Render();
+    if (!interactor->GetDone()) renWin->Render();
+    vtkDebugMacro(<< "PumpEv: Window Render");
   }
 #endif
 }


### PR DESCRIPTION
By adding some debug info, the crash point can be located at that BeginDearImGUIOverlay is called after TearDown, which means the window render should NOT be called at that time. So add a additional condition statement before Render.

You can see the following debug info before and after adding this condition statement:

```
#before:
2021-10-15 12:53:19.182 (   1.413s) [                ]vtkDearImGUIInjector.cp:387   INFO| vtkDearImGUIInjector (0000020805870010): PumpEv
2021-10-15 12:53:19.191 (   1.422s) [                ]vtkDearImGUIInjector.cp:155   INFO| vtkDearImGUIInjector (0000020805870010): BeginDearImGUIOverlay
2021-10-15 12:53:19.199 (   1.430s) [                ]vtkDearImGUIInjector.cp:189   INFO| vtkDearImGUIInjector (0000020805870010): new frame begin
2021-10-15 12:53:19.208 (   1.439s) [                ]vtkDearImGUIInjector.cp:234   INFO| vtkDearImGUIInjector (0000020805870010): new frame end
2021-10-15 12:53:19.218 (   1.449s) [                ]vtkDearImGUIInjector.cp:240   INFO| vtkDearImGUIInjector (0000020805870010): RenderDearImGUIOverlay
2021-10-15 12:53:19.228 (   1.459s) [                ]vtkDearImGUIInjector.cp:387   INFO| vtkDearImGUIInjector (0000020805870010): PumpEv
2021-10-15 12:53:19.306 (   1.537s) [                ]vtkDearImGUIInjector.cp:149   INFO| vtkDearImGUIInjector (0000020805870010): tear down
2021-10-15 12:53:19.322 (   1.553s) [                ]vtkDearImGUIInjector.cp:155   INFO| vtkDearImGUIInjector (0000020805870010): BeginDearImGUIOverlay
2021-10-15 12:53:19.331 (   1.562s) [                ]vtkDearImGUIInjector.cp:189   INFO| vtkDearImGUIInjector (0000020805870010): new frame begin
Assertion failed: bd != 0 && "Did you call ImGui_ImplOpenGL3_Init()?"

#after:
2021-10-15 12:58:21.145 (   1.196s) [                ]vtkDearImGUIInjector.cp:387   INFO| vtkDearImGUIInjector (000001DAB6229AB0): PumpEv: Window Render
2021-10-15 12:58:21.154 (   1.204s) [                ]vtkDearImGUIInjector.cp:155   INFO| vtkDearImGUIInjector (000001DAB6229AB0): BeginDearImGUIOverlay
2021-10-15 12:58:21.162 (   1.213s) [                ]vtkDearImGUIInjector.cp:189   INFO| vtkDearImGUIInjector (000001DAB6229AB0): new frame begin
2021-10-15 12:58:21.170 (   1.221s) [                ]vtkDearImGUIInjector.cp:234   INFO| vtkDearImGUIInjector (000001DAB6229AB0): new frame end
2021-10-15 12:58:21.181 (   1.231s) [                ]vtkDearImGUIInjector.cp:240   INFO| vtkDearImGUIInjector (000001DAB6229AB0): RenderDearImGUIOverlay
2021-10-15 12:58:21.190 (   1.241s) [                ]vtkDearImGUIInjector.cp:387   INFO| vtkDearImGUIInjector (000001DAB6229AB0): PumpEv: Window Render
2021-10-15 12:58:21.284 (   1.335s) [                ]vtkDearImGUIInjector.cp:149   INFO| vtkDearImGUIInjector (000001DAB6229AB0): tear down
2021-10-15 12:58:21.300 (   1.350s) [                ]vtkDearImGUIInjector.cp:387   INFO| vtkDearImGUIInjector (000001DAB6229AB0): PumpEv: Window Render
2021-10-15 12:58:21.311 (   1.361s) [                ]          vtkObject.cxx:892   INFO| vtkDearImGUIInjector (000001DAB6229AB0): UnRegistered by nullptr, ReferenceCount = 0
2021-10-15 12:58:21.322 (   1.373s) [                ]          vtkObject.cxx:170   INFO| vtkObject (000001DAB6229AB0): Destructing!
```